### PR TITLE
URL Cleanup

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -11,7 +11,7 @@ spring:
   profiles: cloud
   cloud:
     config:
-      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:http://user:password@${PREFIX:}configserver.${application.domain:cfapps.io}}
+      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:https://user:password@${PREFIX:}configserver.${application.domain:cfapps.io}}
 oauth2:
   client:
     tokenUri: ${vcap.services.${PREFIX:}sso.credentials.tokenUri:}
@@ -32,7 +32,7 @@ eureka:
     nonSecurePort: 80
   client:
     serviceUrl:
-      defaultZone: ${vcap.services.${PREFIX:}eureka.credentials.uri:http://user:${eureka.password:}@${PREFIX:}eureka.${application.domain:cfapps.io}}/eureka/
+      defaultZone: ${vcap.services.${PREFIX:}eureka.credentials.uri:https://user:${eureka.password:}@${PREFIX:}eureka.${application.domain:cfapps.io}}/eureka/
 hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 60000
 ribbon:
   ConnectTimeout: 3000

--- a/test.json
+++ b/test.json
@@ -5,7 +5,7 @@
     "guid": "2b403b4b-8b4f-4bf4-8fc0-c957e9c92596",
     "isActive": true,
     "balance": "$2,210.39",
-    "picture": "http://placehold.it/32x32",
+    "picture": "https://placehold.it/32x32",
     "age": 25,
     "eyeColor": "blue",
     "name": {
@@ -52,7 +52,7 @@
     "guid": "cbc8e72f-511b-406b-b3c8-d44a5ea78f2f",
     "isActive": true,
     "balance": "$3,096.58",
-    "picture": "http://placehold.it/32x32",
+    "picture": "https://placehold.it/32x32",
     "age": 26,
     "eyeColor": "blue",
     "name": {
@@ -99,7 +99,7 @@
     "guid": "46f24b5b-f8e3-486b-8b3a-0b0784f513d9",
     "isActive": true,
     "balance": "$3,437.48",
-    "picture": "http://placehold.it/32x32",
+    "picture": "https://placehold.it/32x32",
     "age": 39,
     "eyeColor": "green",
     "name": {
@@ -146,7 +146,7 @@
     "guid": "c9f2570b-76c5-4326-809e-fb7797e0d1cc",
     "isActive": false,
     "balance": "$1,543.14",
-    "picture": "http://placehold.it/32x32",
+    "picture": "https://placehold.it/32x32",
     "age": 34,
     "eyeColor": "blue",
     "name": {
@@ -193,7 +193,7 @@
     "guid": "40b284d8-00a3-4778-8215-4781e3ed5df3",
     "isActive": true,
     "balance": "$2,520.39",
-    "picture": "http://placehold.it/32x32",
+    "picture": "https://placehold.it/32x32",
     "age": 24,
     "eyeColor": "blue",
     "name": {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://user (UnknownHostException) with 1 occurrences migrated to:  
  https://user ([https](https://user) result UnknownHostException).
* http://user:password@ (UnknownHostException) with 1 occurrences migrated to:  
  https://user:password@ ([https](https://user:password@) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://placehold.it/32x32 with 5 occurrences migrated to:  
  https://placehold.it/32x32 ([https](https://placehold.it/32x32) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8761/eureka/ with 2 occurrences